### PR TITLE
Adding skip for plugin goals

### DIFF
--- a/src/it/list-phase-pom-skipped/expected.txt
+++ b/src/it/list-phase-pom-skipped/expected.txt
@@ -1,0 +1,1 @@
+Skipping·build·plan·execution.

--- a/src/it/list-phase-pom-skipped/invoker.properties
+++ b/src/it/list-phase-pom-skipped/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate

--- a/src/it/list-phase-pom-skipped/pom.xml
+++ b/src/it/list-phase-pom-skipped/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.github.jcgay.buildplan</groupId>
+  <artifactId>list-phase</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>
+    Test buildplan:list-phase
+  </description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <executions>
+          <execution>
+            <id>list-phase-attached</id>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+            <goals>
+              <goal>list-phase</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/list-phase-pom-skipped/pom.xml
+++ b/src/it/list-phase-pom-skipped/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.github.jcgay.buildplan</groupId>
-  <artifactId>list-phase</artifactId>
+  <artifactId>list-phase-pom-skipped</artifactId>
   <version>1.0-SNAPSHOT</version>
 
   <description>

--- a/src/it/list-phase-pom-skipped/verify.groovy
+++ b/src/it/list-phase-pom-skipped/verify.groovy
@@ -1,0 +1,19 @@
+#!/usr/bin/env groovy
+String buildLog = new File(basedir, 'build.log').text
+
+check(buildLog, new File(basedir, 'expected.txt').text)
+
+def check(String actual, String expected) {
+    try {
+        assert actual.contains(expected)
+    } catch (AssertionError error) {
+        assert printable(actual).contains(printable(expected))
+    }
+}
+
+String printable(String string) {
+    string.replaceAll(" ", "·").replaceAll( "[\n\r]+", "¬\n" )
+}
+
+
+

--- a/src/it/list-phase-pom/expected.txt
+++ b/src/it/list-phase-pom/expected.txt
@@ -1,0 +1,16 @@
+process-resources ---------------------------------------------------
+    + maven-resources-plugin | default-resources     | resources    
+compile -------------------------------------------------------------
+    + maven-compiler-plugin  | default-compile       | compile      
+process-test-resources ----------------------------------------------
+    + maven-resources-plugin | default-testResources | testResources
+test-compile --------------------------------------------------------
+    + maven-compiler-plugin  | default-testCompile   | testCompile  
+test ----------------------------------------------------------------
+    + maven-surefire-plugin  | default-test          | test         
+package -------------------------------------------------------------
+    + maven-jar-plugin       | default-jar           | jar          
+install -------------------------------------------------------------
+    + maven-install-plugin   | default-install       | install      
+deploy --------------------------------------------------------------
+    + maven-deploy-plugin    | default-deploy        | deploy       

--- a/src/it/list-phase-pom/invoker.properties
+++ b/src/it/list-phase-pom/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate

--- a/src/it/list-phase-pom/pom.xml
+++ b/src/it/list-phase-pom/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.github.jcgay.buildplan</groupId>
+  <artifactId>list-phase</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>
+    Test buildplan:list-phase
+  </description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <executions>
+          <execution>
+            <id>list-phase-attached</id>
+            <goals>
+                <goal>list-phase</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/list-phase-pom/pom.xml
+++ b/src/it/list-phase-pom/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.github.jcgay.buildplan</groupId>
-  <artifactId>list-phase</artifactId>
+  <artifactId>list-phase-pom</artifactId>
   <version>1.0-SNAPSHOT</version>
 
   <description>

--- a/src/it/list-phase-pom/verify.groovy
+++ b/src/it/list-phase-pom/verify.groovy
@@ -1,0 +1,19 @@
+#!/usr/bin/env groovy
+String buildLog = new File(basedir, 'build.log').text
+
+check(buildLog, new File(basedir, 'expected.txt').text)
+
+def check(String actual, String expected) {
+    try {
+        assert actual.contains(expected)
+    } catch (AssertionError error) {
+        assert printable(actual).contains(printable(expected))
+    }
+}
+
+String printable(String string) {
+    string.replaceAll(" ", "·").replaceAll( "[\n\r]+", "¬\n" )
+}
+
+
+

--- a/src/it/list-phase-skipped/expected.txt
+++ b/src/it/list-phase-skipped/expected.txt
@@ -1,0 +1,1 @@
+Skipping·build·plan·execution.

--- a/src/it/list-phase-skipped/invoker.properties
+++ b/src/it/list-phase-skipped/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:list-phase -Dbuildplan.skip=true

--- a/src/it/list-phase-skipped/pom.xml
+++ b/src/it/list-phase-skipped/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.github.jcgay.buildplan</groupId>
-  <artifactId>list-phase</artifactId>
+  <artifactId>list-phase-skipped</artifactId>
   <version>1.0-SNAPSHOT</version>
 
   <description>

--- a/src/it/list-phase-skipped/pom.xml
+++ b/src/it/list-phase-skipped/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.github.jcgay.buildplan</groupId>
+  <artifactId>list-phase</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>
+    Test buildplan:list-phase
+  </description>
+
+</project>

--- a/src/it/list-phase-skipped/verify.groovy
+++ b/src/it/list-phase-skipped/verify.groovy
@@ -1,0 +1,19 @@
+#!/usr/bin/env groovy
+String buildLog = new File(basedir, 'build.log').text
+
+check(buildLog, new File(basedir, 'expected.txt').text)
+
+def check(String actual, String expected) {
+    try {
+        assert actual.contains(expected)
+    } catch (AssertionError error) {
+        assert printable(actual).contains(printable(expected))
+    }
+}
+
+String printable(String string) {
+    string.replaceAll(" ", "·").replaceAll( "[\n\r]+", "¬\n" )
+}
+
+
+

--- a/src/it/list-plugin-skipped/expected.txt
+++ b/src/it/list-plugin-skipped/expected.txt
@@ -1,0 +1,1 @@
+Skipping build plan execution.

--- a/src/it/list-plugin-skipped/invoker.properties
+++ b/src/it/list-plugin-skipped/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:list-plugin -Dbuildplan.skip=true

--- a/src/it/list-plugin-skipped/pom.xml
+++ b/src/it/list-plugin-skipped/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.github.jcgay.buildplan</groupId>
-  <artifactId>list-plugin</artifactId>
+  <artifactId>list-plugin-skipped</artifactId>
   <version>1.0-SNAPSHOT</version>
 
   <description>

--- a/src/it/list-plugin-skipped/pom.xml
+++ b/src/it/list-plugin-skipped/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.github.jcgay.buildplan</groupId>
+  <artifactId>list-plugin</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>
+    Test buildplan:list-plugin
+  </description>
+
+</project>

--- a/src/it/list-plugin-skipped/verify.groovy
+++ b/src/it/list-plugin-skipped/verify.groovy
@@ -1,0 +1,19 @@
+#!/usr/bin/env groovy
+String buildLog = new File(basedir, 'build.log').text
+
+check(buildLog, new File(basedir, 'expected.txt').text)
+
+def check(String actual, String expected) {
+    try {
+        assert actual.contains(expected)
+    } catch (AssertionError error) {
+        assert printable(actual).contains(printable(expected))
+    }
+}
+
+String printable(String string) {
+    string.replaceAll(" ", "·").replaceAll( "[\n\r]+", "¬\n" )
+}
+
+
+

--- a/src/main/java/fr/jcgay/maven/plugin/buildplan/AbstractLifecycleMojo.java
+++ b/src/main/java/fr/jcgay/maven/plugin/buildplan/AbstractLifecycleMojo.java
@@ -51,9 +51,9 @@ public abstract class AbstractLifecycleMojo extends AbstractMojo {
     @Parameter(property = "buildplan.appendOutput", defaultValue = "false")
     private boolean appendOutput;
 
-    /** Allow to skip execution  */
+    /** Flag to easily skip all checks  */
     @Parameter(property = "buildplan.skip", defaultValue = "false")
-    private boolean skip;
+    private boolean skip = false;
 
     protected MavenExecutionPlan calculateExecutionPlan() throws MojoFailureException {
         try {
@@ -80,6 +80,7 @@ public abstract class AbstractLifecycleMojo extends AbstractMojo {
     @Override
     public final void execute() throws MojoExecutionException, MojoFailureException {
         if(skip) {
+            getLog().info( "Skipping build plan execution." );
             return;
         }
         executeInternal();

--- a/src/main/java/fr/jcgay/maven/plugin/buildplan/AbstractLifecycleMojo.java
+++ b/src/main/java/fr/jcgay/maven/plugin/buildplan/AbstractLifecycleMojo.java
@@ -19,6 +19,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.lifecycle.LifecycleExecutor;
 import org.apache.maven.lifecycle.MavenExecutionPlan;
 import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -50,6 +51,10 @@ public abstract class AbstractLifecycleMojo extends AbstractMojo {
     @Parameter(property = "buildplan.appendOutput", defaultValue = "false")
     private boolean appendOutput;
 
+    /** Allow to skip execution  */
+    @Parameter(property = "buildplan.skip", defaultValue = "false")
+    private boolean skip;
+
     protected MavenExecutionPlan calculateExecutionPlan() throws MojoFailureException {
         try {
             return lifecycleExecutor.calculateExecutionPlan(session, tasks);
@@ -71,4 +76,14 @@ public abstract class AbstractLifecycleMojo extends AbstractMojo {
             }
         }
     }
+
+    @Override
+    public final void execute() throws MojoExecutionException, MojoFailureException {
+        if(skip) {
+            return;
+        }
+        executeInternal();
+    }
+
+    protected abstract void executeInternal() throws MojoExecutionException, MojoFailureException;
 }

--- a/src/main/java/fr/jcgay/maven/plugin/buildplan/ListMojo.java
+++ b/src/main/java/fr/jcgay/maven/plugin/buildplan/ListMojo.java
@@ -39,7 +39,7 @@ import static fr.jcgay.maven.plugin.buildplan.display.TableColumn.PHASE;
       requiresProject = true)
 public class ListMojo extends AbstractLifecycleMojo {
 
-    public void execute() throws MojoExecutionException, MojoFailureException {
+    public void executeInternal() throws MojoExecutionException, MojoFailureException {
 
         MavenExecutionPlan plan = calculateExecutionPlan();
 

--- a/src/main/java/fr/jcgay/maven/plugin/buildplan/ListPhaseMojo.java
+++ b/src/main/java/fr/jcgay/maven/plugin/buildplan/ListPhaseMojo.java
@@ -43,7 +43,7 @@ public class ListPhaseMojo extends AbstractLifecycleMojo {
     @Parameter(property = "buildplan.phase")
     private String phase;
 
-    public void execute() throws MojoExecutionException, MojoFailureException {
+    public void executeInternal() throws MojoExecutionException, MojoFailureException {
 
         Multimap<String,MojoExecution> phases = Groups.ByPhase.of(calculateExecutionPlan().getMojoExecutions(), phase);
 

--- a/src/main/java/fr/jcgay/maven/plugin/buildplan/ListPluginMojo.java
+++ b/src/main/java/fr/jcgay/maven/plugin/buildplan/ListPluginMojo.java
@@ -43,7 +43,7 @@ public class ListPluginMojo extends AbstractLifecycleMojo {
     @Parameter(property = "buildplan.plugin")
     private String plugin;
 
-    public void execute() throws MojoExecutionException, MojoFailureException {
+    public void executeInternal() throws MojoExecutionException, MojoFailureException {
 
         Multimap<String,MojoExecution> plan = Groups.ByPlugin.of(calculateExecutionPlan().getMojoExecutions(), plugin);
 


### PR DESCRIPTION
We are using this plugin attached to maven lifecycle.

In some cases it comes handy if one could skip the execution of the plugin. Reasons could be speeding up the build or list the phases only when a "debug" flag is set.

This pull request adds the `<skip>true</skip>` configuration element to the pom and the `-Dbuildplan.skip=true` system property to the plugin.

Also added some integration tests to make sure the plugin still works as expected.